### PR TITLE
Eventual-consistency Fix

### DIFF
--- a/examples/test_app/main.tf
+++ b/examples/test_app/main.tf
@@ -9,7 +9,7 @@ resource "aws_iam_role" "test_app" {
         Effect = "Allow"
         Sid    = ""
         Principal = {
-          Service = "ec2.amazonaws.com"
+          Service = "lambda.amazonaws.com"
         }
       },
     ]
@@ -90,4 +90,8 @@ module "helper_lambda" {
 
 output "paths_spec" {
   value = module.helper_lambda.paths_spec
+}
+
+output "all" {
+  value = module.helper_lambda
 }

--- a/main.tf
+++ b/main.tf
@@ -75,3 +75,12 @@ resource "aws_lambda_function" "this" {
 
   tags = var.tags
 }
+
+resource "aws_lambda_alias" "live" {
+  count = var.specification.publish_version ? 1 : 0
+
+  name             = "live"
+  description      = "Live version of the function"
+  function_name    = aws_lambda_function.this.function_name
+  function_version = aws_lambda_function.this.version
+}

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "aws_vpc_security_group_ingress_rule" "ingress" {
 resource "aws_lambda_function" "this" {
   depends_on = [data.archive_file.this]
 
+  publish                        = var.specification.publish_version
   filename                       = "${path.module}/${var.name}.zip"
   function_name                  = lookup(var.specification, "function_name")
   role                           = lookup(var.specification, "role_arn")

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_lambda_function" "this" {
 resource "aws_lambda_alias" "live" {
   count = var.specification.publish_version ? 1 : 0
 
-  name             = "live"
+  name             = var.specification.latest_version_alias
   description      = "Live version of the function"
   function_name    = aws_lambda_function.this.function_name
   function_version = aws_lambda_function.this.version

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "lambda_qualified_arn" {
 }
 
 output "lambda_invoke_arn" {
-  value = aws_lambda_function.this.invoke_arn
+  value = var.specification.publish_version ? one(aws_lambda_alias.live).invoke_arn : aws_lambda_function.this.invoke_arn
 }
 
 output "lambda_qualified_invoke_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,18 @@ output "lambda_function_name" {
   value = aws_lambda_function.this.function_name
 }
 
+output "lambda_qualified_arn" {
+  value = aws_lambda_function.this.qualified_arn
+}
+
+output "lambda_invoke_arn" {
+  value = aws_lambda_function.this.invoke_arn
+}
+
+output "lambda_qualified_invoke_arn" {
+  value = aws_lambda_function.this.qualified_invoke_arn
+}
+
 output "paths_spec" {
   description = "OpenAPI paths spec for use in the API Gateway resource body"
   value       = local.paths_spec
@@ -79,7 +91,7 @@ locals {
           type       = this_method_config.integration.type
           httpMethod = this_method_config.http_method == null ? "POST" : null
           passthroughBehavior : "when_no_match",
-          uri = this_method_config.integration.type != "mock" ? "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${lookup(var.specification, "function_name")}/invocations" : null
+          uri = this_method_config.integration.type != "mock" ? (var.specification.publish_version ? aws_lambda_function.this.qualified_invoke_arn : aws_lambda_function.this.invoke_arn) : null
 
           # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration-responses.html
           #

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,7 +91,7 @@ locals {
           type       = this_method_config.integration.type
           httpMethod = this_method_config.http_method == null ? "POST" : null
           passthroughBehavior : "when_no_match",
-          uri = this_method_config.integration.type != "mock" ? (var.specification.publish_version ? aws_lambda_function.this.qualified_invoke_arn : aws_lambda_function.this.invoke_arn) : null
+          uri = this_method_config.integration.type != "mock" ? (var.specification.publish_version ? one(aws_lambda_alias.live).invoke_arn : aws_lambda_function.this.invoke_arn) : null
 
           # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration-responses.html
           #

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "lambda_invoke_arn" {
   value = var.specification.publish_version ? one(aws_lambda_alias.live).invoke_arn : aws_lambda_function.this.invoke_arn
 }
 
+output "lambda_arn_for_permission" {
+  description = "ARN to use for Lambda permissions (alias ARN when versioned, function ARN otherwise)"
+  value       = var.specification.publish_version ? one(aws_lambda_alias.live).arn : aws_lambda_function.this.arn
+}
+
 output "lambda_qualified_invoke_arn" {
   value = aws_lambda_function.this.qualified_invoke_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,7 @@ variable "specification" {
   description = "Map describing Lambda to API relations"
 
   type = object({
+    publish_version                = optional(bool, true),
     runtime                        = string,
     source_dir                     = string,
     function_name                  = string,

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,7 @@ variable "specification" {
 
   type = object({
     publish_version                = optional(bool, true),
+    latest_version_alias           = optional(string, "live"),
     runtime                        = string,
     source_dir                     = string,
     function_name                  = string,


### PR DESCRIPTION
- Fixed example
- Added option to version Lambdas
- Added Lambda alias for optional version

BREAKING CHANGE: Lambda versions are set to true by default, which means there will be a small downtime for resources like API Gateway which relied on the previous version of this module